### PR TITLE
Fix bug when two todo have the same description

### DIFF
--- a/angular-localStorage-todos/app/views/main.html
+++ b/angular-localStorage-todos/app/views/main.html
@@ -16,7 +16,7 @@
 
   <!-- Todos list -->
   <div ui-sortable ng-model="todos">
-    <p class="input-group" ng-repeat="todo in todos" style="padding:5px 10px; cursor: move;">
+    <p class="input-group" ng-repeat="todo in todos track by $index" style="padding:5px 10px; cursor: move;">
       <input type="text" ng-model="todo" class="form-control" >
       <span class="input-group-btn">
         <button class="btn btn-danger" ng-click="removeTodo($index)" aria-label="Remove">X</button>


### PR DESCRIPTION
When create two todo with the same description we have the exception:

```javascript
 Error: [ngRepeat:dupes] Duplicates in a repeater are not allowed. Use 'track by' expression to specify unique keys. Repeater: todo in todos, Duplicate key: string:
http://errors.angularjs.org/1.2.6/ngRepeat/dupes?p0=todo%20in%20todos&p1=string%3A
    at angular.js:78
    at ngRepeatAction (angular.js:19165)
    at Object.$watchCollectionAction [as fn] (angular.js:11658)
    at Scope.$digest (angular.js:11761)
    at Scope.$apply (angular.js:12012)
    at done (angular.js:7818)
    at completeRequest (angular.js:7991)
    at XMLHttpRequest.xhr.onreadystatechange (angular.js:7947)
```

This PR solve this problem with base in this article:

https://docs.angularjs.org/error/ngRepeat/dupes?p0=todo%20in%20todos&p1=string:
